### PR TITLE
Limited PS2 LTB Mesh Import

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,17 +10,14 @@ Format | Import | Export
 --- | --- | ---
 ABC | Limited | Limited
 LTA | No | No
-LTB (PS2) | WIP | No
+LTB (PS2) | Limited | No
 LTB (PC) | No | No
 
 The ABC file format description can be found on our wiki [here](https://github.com/cmbasnett/io_scene_abc/wiki/ABC).
 
-Additional format information can be found in [here](https://github.com/haekb/io_scene_lithtech/research)
+Additional format information can be found in [here](https://github.com/haekb/io_scene_lithtech/tree/master/research)
 
 ![](https://raw.githubusercontent.com/haekb/io_scene_lithtech/master/doc/readme/example.png)
-
-## Notes
-This addon is a **work in progress**! If you would like to help with this project, please contact me on Discord (Colin Basnett#0827).
 
 ## Known Issues
 Though the animation data format is known, this plugin does not yet support the importing or exporting of animations.

--- a/research/ps2_ltb.bt
+++ b/research/ps2_ltb.bt
@@ -574,7 +574,7 @@ for(i = 0; i < pieceInfo.PieceCount; i++)
 // 530 = same part
 
 // tnt FSeek(4420);
-FSeek(62304);
+FSeek(hdr.NodeOffset - (sizeof(VertexWeights) * info.VertexCount) );
 VertexWeights weights[info.VertexCount];
 
 FSeek(hdr.NodeOffset);

--- a/research/ps2_ltb.bt
+++ b/research/ps2_ltb.bt
@@ -121,7 +121,7 @@ struct MeshSet
 // After Piece and LODSkeletal, this is filled just before LODGlue!
 struct LODStart {
     uint32 VertexCount;
-    uint32 Unknown1;
+    uint32 WeightedNodesCount;
     // Moved these to LODGlue
     //uint32 Unknown2;
     //uint32 Unknown[6];
@@ -229,7 +229,7 @@ struct RandomOne {
 
 struct ExtraFaceData {
     uint32 Unk;
-    short sUnk;
+    //short sUnk;
 };
 
 struct TheUnknown {
@@ -385,6 +385,12 @@ local float heroEight3 = 0.0f;
 local float testFloat = 0.0f;
 local int test = 0;
 
+local int totalStuff = 0;
+
+local int testZero1 = 0;
+local int testZero2 = 0;
+local float testAfter = 0.0f;
+
 // Commented out so I can work on non-geom stuff
 
 // Okay, let's loop through the pieces
@@ -497,7 +503,7 @@ for(i = 0; i < pieceInfo.PieceCount; i++)
                 {
                     FSeek(FTell() + (4*4));
                 }
-
+                totalStuff += 1;
                 MeshData meshData;
             }            
 
@@ -554,10 +560,43 @@ for(i = 0; i < pieceInfo.PieceCount; i++)
             
             if (piece.MeshType == 5) 
             {
-                Printf("Test is %d", test);
+                
+                // Skip some unknown and unknown length values
+                // Seems to be at least 2 4-byte zeroes before the next part!
+                while(true)
+                {
+                    //
+                    testZero1 = 0;
+                    testZero2 = 0;
+                    testAfter = 0.0f;
+            
+                    testZero1 = ReadUInt(FTell());
+                    //testZero2 = ReadUInt(FTell() + 4);
+                    testAfter = ReadFloat(FTell() + 8);
+                    
+                    if (testZero1 == 0 && testAfter != 0.0f)
+                    {
+                        // Finally move past the one zeroes and we're good!
+                        FSeek(FTell() + 4);
+                        break;
+                    }
+                    // Move forward 4 bytes.
+                    FSeek(FTell() + 4);
+                }
+
+
+                Printf("Test is %d\n", test);
                 //TheUnknown unk;
-                ExtraFaceData extraFaceData[info.WeightCount];//[151];//[info.TriangleCount]; //151
-                ExtraVertNorm extraMeshData[info.VertexCount];
+                Printf("Total stuff! %d\n", totalStuff);
+                //ExtraFaceData extraFaceData[totalStuff];//[151];//[info.TriangleCount]; //151
+                ExtraVertNorm extraMeshData[lodStart.VertexCount];
+
+                FSeek(FTell() + (4*info.NodeCount));
+
+
+
+                VertexWeights weights[lodStart.VertexCount];
+
                 ////RandomOne filler[12];
                 //RandomOne one;
                 //VertexWeights weights[info.WeightCount];
@@ -572,7 +611,7 @@ for(i = 0; i < pieceInfo.PieceCount; i++)
 
 // 279 = tail
 // 530 = same part
-
+return;
 // tnt FSeek(4420);
 FSeek(hdr.NodeOffset - (sizeof(VertexWeights) * info.VertexCount) );
 VertexWeights weights[info.VertexCount];

--- a/research/ps2_ltb.bt
+++ b/research/ps2_ltb.bt
@@ -15,6 +15,10 @@ typedef unsigned char		uint8;
 //typedef unsigned short int	uint16;
 //typedef unsigned int		uint32;
 
+struct Vector4 {
+    float x,y,z,w;
+};
+
 struct Vector3 {
     float x,y,z;
 };
@@ -154,7 +158,9 @@ struct Piece {
     float SpecularPower;
     float SpecularScale;
     float LODWeight;
-    float unkFloatyPadding[12];
+    float unkFloatyPadding[9];
+    uint32 TextureIndex; // Maybe?
+    uint32 Unknown[2];
     int Four;
     int MeshType; // Basically confirmed
 };
@@ -162,15 +168,29 @@ struct Piece {
 struct Node {
     uint16 NameLength;
     char   Name[NameLength];
-    uint16 Index;
-    uint16 UnknownPadding;
-    Vector3 Matrix[4];
+    //uint16 Index;
+    //ubyte flag;    
+//uint16 UnknownPadding;
+    Vector4 Matrix[4];
+    short unk1;
+    short unk2;
     uint32 ChildCount;
-    uint32 UnknownPadding2[5];
+    uint32 Unk; // Maybe n levels deep
 };
 
 struct NodeOther {
     uint32 WeightSetCount;
+
+};
+
+struct NodeWeight {
+
+};
+
+struct WeightSet {
+    uint32 Unk;
+    uint32 NodeCount;
+    float Weights[NodeCount];
 };
 
 // Unknown data at the end of a mesh set..only sometimes though.
@@ -185,6 +205,40 @@ struct MeshSetExtended
 struct EndSignal {
     uint32 Padding[3];
     CommandSignal signal;
+};
+//440
+
+struct ExtraVertNorm {
+    Vector3 VertexData;
+    float VertexPadding;
+    Vector3 NormalData;
+    float NormalPadding;
+};
+
+struct RandomOne {
+    uint32 One;
+};
+
+struct VertexWeights {
+    uint32 unk1;
+    uint32 zero;
+    uint32 unk2;
+};
+
+struct ExtraFaceData {
+    uint32 Unk;
+};
+
+struct TheUnknown {
+    short unk[2];
+    // 525 = Floats
+    //float whatevesfloaty[228];
+    //uint32 one;
+};
+
+struct HeroEights {
+    uint32 Ignore;
+    Vector3 Heroes;
 };
 
 //Section section;
@@ -222,11 +276,61 @@ local uchar UnpackVIFCommand = 0;
 local uint32 EndSignalZero[3] = { 0, 0, 0 };
 local uint32 EndSignalData = 0;
 
+local int breakFromPieces = 0;
+local float heroEight1 = 0.0f;
+local float heroEight2 = 0.0f;
+local float heroEight3 = 0.0f;
+
+local int test = 0;
+
 // Okay, let's loop through the pieces
 for(i = 0; i < pieceInfo.PieceCount; i++)
 {
     // Reset some vars
     checkForMoreData = 0;
+    test= 0;
+
+    // HACK
+    // Check for Vector3 of 0.8's
+    // This is constant all the pieces
+/*
+    while(true)
+    {
+        //HeroEights eights;
+        heroEight1 = 0.0f;
+        heroEight2 = 0.0f;
+        heroEight3 = 0.0f;
+    
+        // Skip first item in Piece
+        peekAmount = 4;
+
+        heroEight1 = ReadFloat(FTell() + peekAmount);
+        heroEight2 = ReadFloat(FTell() + peekAmount + 4);
+        heroEight3 = ReadFloat(FTell() + peekAmount + 8);
+
+        if (heroEight1 == 0.8f && heroEight2 == 0.8f && heroEight3 == 0.8f)
+        {
+            break;
+        }
+
+        // Slowly crawl us up one int at a time!
+        FSeek( FTell() + 4 );
+
+        if (FTell() + (4*4) >= FileSize())
+        {
+            breakFromPieces = 1;
+            break;
+        }
+    }
+*/
+    //FSeek( FTell() - 4 );
+
+    if (breakFromPieces)
+    {
+        break;
+    }
+
+    //
 
     Piece piece;
 
@@ -237,6 +341,7 @@ for(i = 0; i < pieceInfo.PieceCount; i++)
 
     LODStart lodStart;
 
+    // Per LOD?
     while (true)
     {
         // If they reached about 13kb of data
@@ -291,6 +396,7 @@ for(i = 0; i < pieceInfo.PieceCount; i++)
             }
     
             meshSetIndex++;
+            test += Data.DataCount;
         }
         
         // Check ahead for the end signal, sometimes there's an extra 4*4 row of floats.
@@ -314,6 +420,7 @@ for(i = 0; i < pieceInfo.PieceCount; i++)
         // Calculate batch size
         setSize = setEnd - setStart;
 
+        Printf("size (%d) = size_end (%d) - size_start (%d)\n", setSize, setEnd, setStart);
         Printf("Set Size is %d\n", setSize);
         
         // Monolith chose around 13kb as the batch size limit
@@ -325,11 +432,28 @@ for(i = 0; i < pieceInfo.PieceCount; i++)
         } 
         else // If we're not at that cap, then we can safely assume there's no more batched data here.
         {
+            /*
+            if (piece.MeshType == 5) 
+            {
+                Printf("Test is %d", test);
+                TheUnknown unk;
+                ExtraFaceData extraFaceData[info.TriangleCount];
+                ExtraVertNorm extraMeshData[info.VertexCount];
+                //RandomOne filler[12];
+                RandomOne one;
+                VertexWeights weights[info.WeightCount];
+            }
+            */
             break;
         }
+
+        
     }
 }
 
 FSeek(hdr.NodeOffset);
 Node node[info.NodeCount] <optimize=false>;
+
+// Actually Anim WeightSet, see dog_action.lta / ltb
 NodeOther nodeOther;
+WeightSet weights[nodeOther.WeightSetCount];

--- a/research/ps2_ltb.bt
+++ b/research/ps2_ltb.bt
@@ -111,7 +111,7 @@ struct MeshSet
     uchar UnknownFlag; // If 128, then it's the last Set!
     short Padding;
     uint32 Unknown1;
-    uint32 Unknown2;
+    uint32 WindingOrder;
     uint32 Unknown3;
     MeshData Data[DataCount] <optimize=false>;
 };
@@ -234,6 +234,7 @@ struct VertexWeights {
 
 struct ExtraFaceData {
     uint32 Unk;
+    short sUnk;
 };
 
 struct TheUnknown {
@@ -370,7 +371,7 @@ local float heroEight3 = 0.0f;
 local int test = 0;
 
 // Commented out so I can work on non-geom stuff
-/*
+
 // Okay, let's loop through the pieces
 for(i = 0; i < pieceInfo.PieceCount; i++)
 {
@@ -384,6 +385,8 @@ for(i = 0; i < pieceInfo.PieceCount; i++)
 
     while(true)
     {
+        // DEBUG: Testing weights
+        break;
         //HeroEights eights;
         heroEight1 = 0.0f;
         heroEight2 = 0.0f;
@@ -525,8 +528,8 @@ for(i = 0; i < pieceInfo.PieceCount; i++)
             {
                 Printf("Test is %d", test);
                 //TheUnknown unk;
-                //ExtraFaceData extraFaceData[info.TriangleCount];
-                //ExtraVertNorm extraMeshData[info.VertexCount];
+                ExtraFaceData extraFaceData[info.WeightCount];//[151];//[info.TriangleCount]; //151
+                ExtraVertNorm extraMeshData[info.VertexCount];
                 ////RandomOne filler[12];
                 //RandomOne one;
                 //VertexWeights weights[info.WeightCount];
@@ -538,7 +541,7 @@ for(i = 0; i < pieceInfo.PieceCount; i++)
         
     }
 }
-*/
+
 
 FSeek(hdr.NodeOffset);
 Node node[info.NodeCount] <optimize=false>;

--- a/research/ps2_ltb.bt
+++ b/research/ps2_ltb.bt
@@ -26,6 +26,10 @@ struct TexCoord {
     float u,v;
 };
 
+struct Quat {
+    float x,y,z,w;
+};
+
 // I'm bad at names, but this must mean something for the PS2.
 // VIFCodes: https://gtamods.com/wiki/PS2_Native_Geometry
 //
@@ -172,10 +176,12 @@ struct Node {
     //ubyte flag;    
 //uint16 UnknownPadding;
     Vector4 Matrix[4];
-    short unk1;
-    short unk2;
+    ubyte unkB1;
+    ubyte unkB2;
+    ushort unk2;
     uint32 ChildCount;
-    uint32 Unk; // Maybe n levels deep
+    short Index; // 
+    short Unk; // Maybe flag?
 };
 
 struct NodeOther {
@@ -187,8 +193,9 @@ struct NodeWeight {
 
 };
 
+// Currently only Anim-Weightset?
 struct WeightSet {
-    uint32 Unk;
+    uint32 ID;
     uint32 NodeCount;
     float Weights[NodeCount];
 };
@@ -241,6 +248,85 @@ struct HeroEights {
     Vector3 Heroes;
 };
 
+struct Socket {
+/*
+        socket = Socket()
+        socket.node_index = unpack('I', f)[0]
+        socket.name = self._read_string(f)
+        socket.rotation = self._read_quaternion(f)
+        socket.location = self._read_vector(f)
+*/
+    uint32 unk1;
+    Quat rotation;
+    Vector3 location;
+    uint32 padding;
+    uint32 nodeIndex;
+    uint32 unk2;
+    uint32 unk3;
+};
+
+
+
+struct ChildModel {
+    short stringLength;
+    char Name[stringLength];
+};
+struct ChildModelHeader {
+    uint32 Count;
+};
+
+struct AnimationHeader {
+    uint32 Count;
+};
+
+struct KeyFrame {
+    ushort Time;
+    uint32 Padding;
+};
+
+
+
+struct CompressedFrame {
+    short Padding;
+    short Location[3]; 
+    short Rotation[4]; 
+};
+
+struct CVector3 {
+    short x,y,z;
+};
+
+struct CQuat {
+    short x,y,z,w;
+};
+
+
+struct NodeKeyframe (uint32 Count)
+{
+    uint32 StartMarker;
+    
+    //int16 unk[34];
+    // This should be per node...
+    CompressedFrame Frames[KeyFrameCount];//[nodeCount];
+};
+
+// Around 543 long
+struct Animation (uint32 nodeCount) {
+    Vector3 Dims;
+    Vector3 Translation;
+    uint32 Unk;
+    uint32 InterpolationTime;
+    uint32 KeyFrameCount;
+    KeyFrame KeyFrames[KeyFrameCount];
+    
+    // Maybe they're just compressed?
+    CVector3 Locations[KeyFrameCount];
+    CQuat Rotations[KeyFrameCount];
+
+    //short test;
+    //NodeKeyframe Nodes(KeyFrameCount)[nodeCount];
+};//5052
+
 //Section section;
 Header hdr;
 ModelInfo info;
@@ -283,6 +369,8 @@ local float heroEight3 = 0.0f;
 
 local int test = 0;
 
+// Commented out so I can work on non-geom stuff
+/*
 // Okay, let's loop through the pieces
 for(i = 0; i < pieceInfo.PieceCount; i++)
 {
@@ -293,7 +381,7 @@ for(i = 0; i < pieceInfo.PieceCount; i++)
     // HACK
     // Check for Vector3 of 0.8's
     // This is constant all the pieces
-/*
+
     while(true)
     {
         //HeroEights eights;
@@ -322,7 +410,7 @@ for(i = 0; i < pieceInfo.PieceCount; i++)
             break;
         }
     }
-*/
+
     //FSeek( FTell() - 4 );
 
     if (breakFromPieces)
@@ -432,24 +520,25 @@ for(i = 0; i < pieceInfo.PieceCount; i++)
         } 
         else // If we're not at that cap, then we can safely assume there's no more batched data here.
         {
-            /*
+            
             if (piece.MeshType == 5) 
             {
                 Printf("Test is %d", test);
-                TheUnknown unk;
-                ExtraFaceData extraFaceData[info.TriangleCount];
-                ExtraVertNorm extraMeshData[info.VertexCount];
-                //RandomOne filler[12];
-                RandomOne one;
-                VertexWeights weights[info.WeightCount];
+                //TheUnknown unk;
+                //ExtraFaceData extraFaceData[info.TriangleCount];
+                //ExtraVertNorm extraMeshData[info.VertexCount];
+                ////RandomOne filler[12];
+                //RandomOne one;
+                //VertexWeights weights[info.WeightCount];
             }
-            */
+            
             break;
         }
 
         
     }
 }
+*/
 
 FSeek(hdr.NodeOffset);
 Node node[info.NodeCount] <optimize=false>;
@@ -457,3 +546,19 @@ Node node[info.NodeCount] <optimize=false>;
 // Actually Anim WeightSet, see dog_action.lta / ltb
 NodeOther nodeOther;
 WeightSet weights[nodeOther.WeightSetCount];
+
+FSeek(hdr.SubModelOffset);
+ChildModelHeader childModelHdr;
+// For some reason it's off by one
+ChildModel ChildModels[info.ChildModelCount - 1] <optimize=false>;
+
+FSeek(hdr.AnimationOffset);
+AnimationHeader animationHdr;
+
+Animation animation(info.NodeCount)[info.AnimationCount] <optimize=false>;
+
+
+
+FSeek(hdr.SocketOffset);
+Socket sockets[info.SocketCount] <optimize=false>;
+ 

--- a/research/ps2_ltb.bt
+++ b/research/ps2_ltb.bt
@@ -158,7 +158,7 @@ struct PieceInfo {
 };
 
 struct Piece {
-    uint32 Padding1;
+    uint32 NodeReference;//Padding1;
     float SpecularPower;
     float SpecularScale;
     float LODWeight;
@@ -176,9 +176,10 @@ struct Node {
     //ubyte flag;    
 //uint16 UnknownPadding;
     Vector4 Matrix[4];
-    ubyte unkB1;
-    ubyte unkB2;
-    ushort unk2;
+    uint32 ParentPiece;
+    //ubyte unkB1;
+    //ubyte unkB2;
+    //ushort unk2;
     uint32 ChildCount;
     short Index; // 
     short Unk; // Maybe flag?
@@ -224,12 +225,6 @@ struct ExtraVertNorm {
 
 struct RandomOne {
     uint32 One;
-};
-
-struct VertexWeights {
-    uint32 unk1;
-    uint32 zero;
-    uint32 unk2;
 };
 
 struct ExtraFaceData {
@@ -327,6 +322,23 @@ struct Animation (uint32 nodeCount) {
     //short test;
     //NodeKeyframe Nodes(KeyFrameCount)[nodeCount];
 };//5052
+
+struct WeightHeader {
+    uint32 Count;
+};
+
+struct VertexWeights {
+    // Weights add up to 4096
+    short firstWeight;
+    short secondWeight;
+    short thirdWeight;
+    short forthWeight;
+    // -1 = Not used
+    char firstNode;
+    char secondNode;
+    char thirdNode;
+    char forthNode;
+};
 
 // trhis is a test I'm testing without mouse control enabled
 //Section section;
@@ -558,6 +570,12 @@ for(i = 0; i < pieceInfo.PieceCount; i++)
     }
 }
 
+// 279 = tail
+// 530 = same part
+
+// tnt FSeek(4420);
+FSeek(62304);
+VertexWeights weights[info.VertexCount];
 
 FSeek(hdr.NodeOffset);
 Node node[info.NodeCount] <optimize=false>;

--- a/research/ps2_ltb.bt
+++ b/research/ps2_ltb.bt
@@ -498,8 +498,9 @@ for(i = 0; i < pieceInfo.PieceCount; i++)
                     FSeek(FTell() + (4*4));
                 }
                 totalStuff += 1;
-                //MeshData meshData;
-                FSeek(FTell() + sizeof(MeshData));
+
+                MeshData meshData;
+                //FSeek(FTell() + sizeof(MeshData));
             }            
 
             //MeshSet Data <optimize=false>;
@@ -555,30 +556,6 @@ for(i = 0; i < pieceInfo.PieceCount; i++)
            
             if (piece.MeshType == 5) 
             {
-/*
-                testZero1 = FTell();
-                Printf("Start unknown sector skip at %d\n", testZero1);
-                // Skip some unknown and unknown length values
-                // Just skip until we reach a valid non-zero float.
-                // I hope I can figure this out before I reach a case where the first vertex is 0.0...
-                while(true)
-                {
-                    testAfter = ReadFloat(FTell());
-                    //Printf("Testing character to see if it's a float: %f\n", testAfter);
-                    //if (testAfter != 0.0f)
-                    if (testAfter > 0.000001 || testAfter < -0.000001)
-                    {
-                        // Finally move past the one zeroes and we're good!
-                        //FSeek(FTell() + 4);
-                        break;
-                    }
-                    // Move forward 4 bytes.
-                    FSeek(FTell() + 4);
-                }
-                testZero2 = FTell();
-                Printf("Finish unknown sector skip at %d\n", testZero2);
-                Printf("Total size of unknown sector: %d\n", testZero2 - testZero1);
-*/
                 testZero1 = FTell();
                 while (true)
                 {

--- a/research/ps2_ltb.bt
+++ b/research/ps2_ltb.bt
@@ -113,7 +113,7 @@ struct MeshSet
     uint32 Unknown1;
     uint32 WindingOrder;
     uint32 Unknown3;
-    MeshData Data[DataCount] <optimize=false>;
+    
 };
 
 // LOD Zone!
@@ -328,6 +328,7 @@ struct Animation (uint32 nodeCount) {
     //NodeKeyframe Nodes(KeyFrameCount)[nodeCount];
 };//5052
 
+// trhis is a test I'm testing without mouse control enabled
 //Section section;
 Header hdr;
 ModelInfo info;
@@ -338,6 +339,7 @@ FSeek(hdr.PieceOffset);
 PieceInfo pieceInfo;
 
 local int i = 0;
+local int j = 0;
 local int count = 0;
 local int meshSetIndex = 0;
 local uint32 meshSetCheck = 0;
@@ -368,6 +370,7 @@ local float heroEight1 = 0.0f;
 local float heroEight2 = 0.0f;
 local float heroEight3 = 0.0f;
 
+local float testFloat = 0.0f;
 local int test = 0;
 
 // Commented out so I can work on non-geom stuff
@@ -472,8 +475,21 @@ for(i = 0; i < pieceInfo.PieceCount; i++)
             {
                 FSkip(4*4);
             }
-    
+
+            test = 0;
             MeshSet Data <optimize=false>;
+            for (j = 0; j < Data.DataCount; j++)
+            {
+                testFloat = ReadFloat(FTell() + (4*3));
+                if (testFloat != 1.0f)
+                {
+                    FSeek(FTell() + (4*4));
+                }
+
+                MeshData meshData;
+            }            
+
+            //MeshSet Data <optimize=false>;
             count += Data.DataCount;
     
             if (count >= lod.MeshDataCount)
@@ -558,7 +574,7 @@ ChildModel ChildModels[info.ChildModelCount - 1] <optimize=false>;
 FSeek(hdr.AnimationOffset);
 AnimationHeader animationHdr;
 
-Animation animation(info.NodeCount)[info.AnimationCount] <optimize=false>;
+//Animation animation(info.NodeCount)[info.AnimationCount] <optimize=false>;
 
 
 

--- a/research/ps2_ltb.bt
+++ b/research/ps2_ltb.bt
@@ -143,7 +143,9 @@ struct LOD {
 };
 
 struct LODSkeletal {
-    uint32 SkelUnknown[2];
+    uint32 SkelUnk;
+    uint32 UnknownSectorSize; // This number may need to be rounded or aligned
+    //uint32 SkelUnknown[2];
 };
 // End LOD Zone!
 
@@ -216,12 +218,18 @@ struct EndSignal {
 };
 //440
 
+
 struct ExtraVertNorm {
     Vector3 VertexData;
     float VertexPadding;
     Vector3 NormalData;
     float NormalPadding;
 };
+
+struct ExtraVertNormWrapper (uint32 count) {
+    ExtraVertNorm list[count] <optimize=false>;
+};
+
 
 struct RandomOne {
     uint32 One;
@@ -340,6 +348,23 @@ struct VertexWeights {
     char forthNode;
 };
 
+struct VertexWeightsWrapper (uint32 count) {
+    VertexWeights weights[count] <optimize=false>;
+};
+
+struct UnknownSector {
+    short unknownValues[2];
+};
+
+struct UnknownSectorWrapper (uint32 count) {
+    UnknownSector unk[count] <optimize=false>;
+};
+
+struct UnknownSectorAlt {
+    short Count;
+    short Values[Count];
+};
+
 // trhis is a test I'm testing without mouse control enabled
 //Section section;
 Header hdr;
@@ -391,49 +416,18 @@ local int testZero1 = 0;
 local int testZero2 = 0;
 local float testAfter = 0.0f;
 
+local int pad = 0;
+
 // Commented out so I can work on non-geom stuff
 
 // Okay, let's loop through the pieces
 for(i = 0; i < pieceInfo.PieceCount; i++)
 {
+    Printf("----------\nNew Piece\n");
+
     // Reset some vars
     checkForMoreData = 0;
     test= 0;
-
-    // HACK
-    // Check for Vector3 of 0.8's
-    // This is constant all the pieces
-
-    while(true)
-    {
-        // DEBUG: Testing weights
-        break;
-        //HeroEights eights;
-        heroEight1 = 0.0f;
-        heroEight2 = 0.0f;
-        heroEight3 = 0.0f;
-    
-        // Skip first item in Piece
-        peekAmount = 4;
-
-        heroEight1 = ReadFloat(FTell() + peekAmount);
-        heroEight2 = ReadFloat(FTell() + peekAmount + 4);
-        heroEight3 = ReadFloat(FTell() + peekAmount + 8);
-
-        if (heroEight1 == 0.8f && heroEight2 == 0.8f && heroEight3 == 0.8f)
-        {
-            break;
-        }
-
-        // Slowly crawl us up one int at a time!
-        FSeek( FTell() + 4 );
-
-        if (FTell() + (4*4) >= FileSize())
-        {
-            breakFromPieces = 1;
-            break;
-        }
-    }
 
     //FSeek( FTell() - 4 );
 
@@ -504,7 +498,8 @@ for(i = 0; i < pieceInfo.PieceCount; i++)
                     FSeek(FTell() + (4*4));
                 }
                 totalStuff += 1;
-                MeshData meshData;
+                //MeshData meshData;
+                FSeek(FTell() + sizeof(MeshData));
             }            
 
             //MeshSet Data <optimize=false>;
@@ -545,8 +540,8 @@ for(i = 0; i < pieceInfo.PieceCount; i++)
         // Calculate batch size
         setSize = setEnd - setStart;
 
-        Printf("size (%d) = size_end (%d) - size_start (%d)\n", setSize, setEnd, setStart);
-        Printf("Set Size is %d\n", setSize);
+        //Printf("size (%d) = size_end (%d) - size_start (%d)\n", setSize, setEnd, setStart);
+        //Printf("Set Size is %d\n", setSize);
         
         // Monolith chose around 13kb as the batch size limit
         // (The max possible size is 16kb!)
@@ -557,50 +552,77 @@ for(i = 0; i < pieceInfo.PieceCount; i++)
         } 
         else // If we're not at that cap, then we can safely assume there's no more batched data here.
         {
-            
+           
             if (piece.MeshType == 5) 
             {
-                
+/*
+                testZero1 = FTell();
+                Printf("Start unknown sector skip at %d\n", testZero1);
                 // Skip some unknown and unknown length values
-                // Seems to be at least 2 4-byte zeroes before the next part!
+                // Just skip until we reach a valid non-zero float.
+                // I hope I can figure this out before I reach a case where the first vertex is 0.0...
                 while(true)
                 {
-                    //
-                    testZero1 = 0;
-                    testZero2 = 0;
-                    testAfter = 0.0f;
-            
-                    testZero1 = ReadUInt(FTell());
-                    //testZero2 = ReadUInt(FTell() + 4);
-                    testAfter = ReadFloat(FTell() + 8);
-                    
-                    if (testZero1 == 0 && testAfter != 0.0f)
+                    testAfter = ReadFloat(FTell());
+                    //Printf("Testing character to see if it's a float: %f\n", testAfter);
+                    //if (testAfter != 0.0f)
+                    if (testAfter > 0.000001 || testAfter < -0.000001)
                     {
                         // Finally move past the one zeroes and we're good!
-                        FSeek(FTell() + 4);
+                        //FSeek(FTell() + 4);
                         break;
                     }
                     // Move forward 4 bytes.
                     FSeek(FTell() + 4);
                 }
+                testZero2 = FTell();
+                Printf("Finish unknown sector skip at %d\n", testZero2);
+                Printf("Total size of unknown sector: %d\n", testZero2 - testZero1);
+*/
+                testZero1 = FTell();
+                while (true)
+                {
+                    UnknownSectorAlt unkSector;
 
+                    // While this works kinda, you need to account for some skipping
+                    testZero2 = FTell();
 
-                Printf("Test is %d\n", test);
-                //TheUnknown unk;
-                Printf("Total stuff! %d\n", totalStuff);
-                //ExtraFaceData extraFaceData[totalStuff];//[151];//[info.TriangleCount]; //151
-                ExtraVertNorm extraMeshData[lodStart.VertexCount];
+                    if( ((testZero2 - testZero1) / 2) >= lodSkeletal.UnknownSectorSize)
+                    {   
+                        while(true) 
+                        {
 
-                FSeek(FTell() + (4*info.NodeCount));
+                            // Look for the 1.0 vertex padding
+                            testAfter = ReadFloat(FTell() + (4*3));
+                            if (testAfter == 1.0f)
+                            {
+                                Printf("Found 1.0f 3 ints away at %d, 1.0f position: %d\n", FTell(), FTell() + (4*3));
+                                break;
+                            }
+                            // Skip 2 bytes, because there may be a short of line padding...
+                            FSkip(2);
+                        }
+                        // Super hack: Use the remainder value to break through twice.
+                        if (testAfter == 1.0f)
+                        {
+                            break;
+                        }
+                    }
+                }
+                testZero2 = FTell();
+                Printf("Finish unknown sector skip at %d\n", testZero2);
+                Printf("Total size of unknown sector: %d\n", testZero2 - testZero1);
+                //UnknownSectorWrapper unkSector(lodSkeletal.UnknownSectorSize);
 
+                ExtraVertNormWrapper extraMeshData(lodStart.VertexCount) <optimize=false>;
 
+                // Skip past the indexed bone list
+                FSeek(FTell() + (4*lodStart.WeightedNodesCount));
 
-                VertexWeights weights[lodStart.VertexCount];
+                VertexWeightsWrapper weights(lodStart.VertexCount) <optimize=false>;
 
-                ////RandomOne filler[12];
-                //RandomOne one;
-                //VertexWeights weights[info.WeightCount];
             }
+
             
             break;
         }
@@ -611,17 +633,17 @@ for(i = 0; i < pieceInfo.PieceCount; i++)
 
 // 279 = tail
 // 530 = same part
-return;
+//return;
 // tnt FSeek(4420);
 FSeek(hdr.NodeOffset - (sizeof(VertexWeights) * info.VertexCount) );
-VertexWeights weights[info.VertexCount];
+//VertexWeights weights[info.VertexCount];
 
 FSeek(hdr.NodeOffset);
 Node node[info.NodeCount] <optimize=false>;
 
 // Actually Anim WeightSet, see dog_action.lta / ltb
 NodeOther nodeOther;
-WeightSet weights[nodeOther.WeightSetCount];
+WeightSet weightSets[nodeOther.WeightSetCount];
 
 FSeek(hdr.SubModelOffset);
 ChildModelHeader childModelHdr;

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -23,6 +23,7 @@ if 'bpy' in locals():
     if 'writer'     in locals(): importlib.reload(writer)
     if 'importer'   in locals(): importlib.reload(importer)
     if 'exporter'   in locals(): importlib.reload(exporter)
+    if 'converter'  in locals(): importlib.reload(converter)
 
 import bpy
 from . import s3tc
@@ -34,13 +35,15 @@ from . import reader_ltb_ps2
 from . import writer
 from . import importer
 from . import exporter
+from . import converter
 
 from bpy.utils import register_class, unregister_class
 
 classes = (
     importer.ImportOperatorABC,
     importer.ImportOperatorLTB,
-    exporter.ExportOperator
+    exporter.ExportOperator,
+    converter.ConvertLTBToABC,
 )
 
 def register():
@@ -48,9 +51,11 @@ def register():
         register_class(cls)
     # bpy.utils.register_module(__name__)
 
+    # Import options
     bpy.types.TOPBAR_MT_file_import.append(importer.ImportOperatorABC.menu_func_import)
     bpy.types.TOPBAR_MT_file_import.append(importer.ImportOperatorLTB.menu_func_import)
 
+    # Export options
     bpy.types.TOPBAR_MT_file_export.append(exporter.ExportOperator.menu_func_export)
 
 
@@ -58,8 +63,11 @@ def unregister():
     for cls in reversed(classes):
         unregister_class(cls)
     #bpy.utils.unregister_module(__name__)
+
+    # Import options
     bpy.types.TOPBAR_MT_file_import.remove(importer.ImportOperatorABC.menu_func_import)
     bpy.types.TOPBAR_MT_file_import.remove(importer.ImportOperatorLTB.menu_func_import)
 
+    # Export options
     bpy.types.TOPBAR_MT_file_export.remove(exporter.ExportOperator.menu_func_export)
 

--- a/src/abc.py
+++ b/src/abc.py
@@ -56,6 +56,7 @@ class FaceVertex(object):
     def __init__(self):
         self.texcoord = Vector()
         self.vertex_index = 0
+        self.reversed = False
 
 
 class Face(object):

--- a/src/builder.py
+++ b/src/builder.py
@@ -8,16 +8,16 @@ def convert_blender_matrix_to_lt_matrix(mat):
     new_mat = Matrix()
 
     new_mat[0][0] = -mat[0][1]
-    new_mat[0][1] = -mat[0][2]
+    new_mat[0][1] = mat[0][2]
     new_mat[0][2] = -mat[0][0]
 
     new_mat[1][0] = -mat[1][1]
     new_mat[1][1] = mat[1][2]
-    new_mat[1][2] = mat[1][0]
+    new_mat[1][2] = -mat[1][0]
 
     new_mat[2][0] = -mat[2][1]
     new_mat[2][1] = mat[2][2]
-    new_mat[2][2] = mat[2][0]
+    new_mat[2][2] = -mat[2][0]
 
     # This is just 0,0,0,1, so can't really test out where the -1 goes.
     new_mat[3][0] = mat[3][1]
@@ -179,6 +179,7 @@ class ModelBuilder(object):
 
         ''' ChildModels '''
         child_model = ChildModel()
+
         for _ in model.nodes:
             child_model.transforms.append(Animation.Keyframe.Transform())
         model.child_models.append(child_model)
@@ -204,7 +205,7 @@ class ModelBuilder(object):
                     matrix = parent_matrix.inverted() @ matrix
 
                 # FIXME: This produces garbled animations
-                transform.matrix = process_matrix(matrix, local_rot)
+                transform.matrix = matrix # process_matrix(matrix, local_rot)
 
                 #transform.location = pose_bone.location
                 #transform.rotation = pose_bone.rotation_quaternion

--- a/src/converter.py
+++ b/src/converter.py
@@ -1,0 +1,129 @@
+'''
+This is a work-around to get PS2 NOLF models into PC NOLF format.
+This mainly a total hack, and probably will be removed once animations and exporting is fixed.
+'''
+import bpy
+import bpy_extras
+import bmesh
+import os
+import math
+from math import pi
+from mathutils import Vector, Matrix, Quaternion, Euler
+from bpy.props import StringProperty, BoolProperty, FloatProperty
+from .dtx import DTX
+from .utils import show_message_box
+from .abc import *
+
+from .reader_ltb_ps2 import PS2LTBModelReader
+from .writer import ModelWriter
+
+
+class ConvertLTBToABC(bpy.types.Operator, bpy_extras.io_utils.ImportHelper):
+    """This appears in the tooltip of the operator and in the generated docs"""
+    bl_idname = 'io_scene_lithtech.ltb_convert'  # important since its how bpy.ops.import_test.some_data is constructed
+    bl_label = 'Convert Lithtech LTB to ABC'
+    bl_space_type = 'PROPERTIES'
+    bl_region_type = 'WINDOW'
+
+    # ImportHelper mixin class uses this
+    filename_ext = ".ltb"
+
+    filter_glob: StringProperty(
+        default="*.ltb",
+        options={'HIDDEN'},
+        maxlen=255,  # Max internal buffer length, longer would be clamped.
+    )
+
+    def execute(self, context):
+        # Import the model
+        model = PS2LTBModelReader().from_file(self.filepath)
+        model.name = os.path.splitext(os.path.basename(self.filepath))[0]
+
+        # Fill in some parts of the model we currently dont..
+        stubber = ModelStubber()
+        model = stubber.execute(model)
+
+        ltb_path = self.filepath
+        abc_path = self.filepath.replace('ltb', 'abc')
+
+        print ("Converting %s to %s" % (ltb_path, abc_path) )
+
+        ModelWriter().write(model, abc_path)
+
+        return {'FINISHED'}
+
+    @staticmethod
+    def menu_func_import(self, context):
+        self.layout.operator(ConvertLTBToABC.bl_idname, text='Convert PS2 LTB to ABC.')
+
+class ModelStubber(object):
+    def execute(self, model):
+
+        # Set the first node as removable
+        model.nodes[0].is_removable = True
+
+        # First node seems to be off...
+        model.nodes[0].bind_matrix = Matrix()
+
+        model.nodes[0].bind_matrix[0][0] = -1.0
+        model.nodes[0].bind_matrix[0][1] = 0.0
+        model.nodes[0].bind_matrix[0][2] = 0.0
+        model.nodes[0].bind_matrix[0][3] = 0.0
+
+        model.nodes[0].bind_matrix[1][0] = 0.0
+        model.nodes[0].bind_matrix[1][1] = -1.0
+        model.nodes[0].bind_matrix[1][2] = 0.0
+        model.nodes[0].bind_matrix[1][3] = -1.543487
+
+        model.nodes[0].bind_matrix[2][0] = 0.0
+        model.nodes[0].bind_matrix[2][1] = 0.0
+        model.nodes[0].bind_matrix[2][2] = 1.0
+        model.nodes[0].bind_matrix[2][3] = 0.0
+
+        model.nodes[0].bind_matrix[3][0] = 0.0
+        model.nodes[0].bind_matrix[3][1] = 0.0
+        model.nodes[0].bind_matrix[3][2] = 0.0
+        model.nodes[0].bind_matrix[3][3] = 1.0
+
+        '''
+        This function will just create fake parts of the model
+        Because LithTech needs at least something in every section!
+        '''
+        animation = Animation()
+        animation.name = 'ConvertedFromPS2'
+        animation.extents = Vector((10, 10, 10))
+        animation.keyframes.append(Animation.Keyframe())
+        for node_index, (node) in enumerate(model.nodes):
+            transforms = list()
+            for _ in animation.keyframes:
+                transform = Animation.Keyframe.Transform()
+                transforms.append(transform)
+            animation.node_keyframe_transforms.append(transforms)
+        model.animations.append(animation)
+
+        ''' ChildModels '''
+        child_model = ChildModel()
+
+        for _ in model.nodes:
+            child_model.transforms.append(Animation.Keyframe.Transform())
+        model.child_models.append(child_model)
+
+        ''' AnimBindings '''
+        anim_binding = AnimBinding()
+        anim_binding.name = 'base'
+        animation.extents = Vector((10, 10, 10))
+        model.anim_bindings.append(anim_binding)
+
+        # Save me some time renaming stuff..
+        # PS2 doesn't have names for sockets
+        human_socket_list = ["RightHand", "Head", "Eyes", "Back", "Nose", "Chin", "LeftHand", "LeftFoot", "RightFoot", "Snowmobile", "Motorcycle"]
+
+        print( len(model.sockets) , len(human_socket_list))
+
+        if len(model.sockets) == len(human_socket_list):
+            for i in range( len(model.sockets) ):
+                model.sockets[i].name = human_socket_list[i]
+            
+        print(model.sockets[0])
+
+        return model

--- a/src/converter.py
+++ b/src/converter.py
@@ -21,7 +21,7 @@ from .writer import ModelWriter
 class ConvertLTBToABC(bpy.types.Operator, bpy_extras.io_utils.ImportHelper):
     """This appears in the tooltip of the operator and in the generated docs"""
     bl_idname = 'io_scene_lithtech.ltb_convert'  # important since its how bpy.ops.import_test.some_data is constructed
-    bl_label = 'Convert Lithtech LTB to ABC'
+    bl_label = 'Convert Lithtech PS2 LTB to ABC'
     bl_space_type = 'PROPERTIES'
     bl_region_type = 'WINDOW'
 
@@ -85,18 +85,25 @@ class ModelStubber(object):
         model.nodes[0].bind_matrix[3][2] = 0.0
         model.nodes[0].bind_matrix[3][3] = 1.0
 
+        # Fix specular power, scale, and lod weight
+        for i in range(len(model.pieces)):
+            model.pieces[i].specular_power = 5.0
+            model.pieces[i].specular_scale = 1.0
+            model.pieces[i].lod_weight = 1.0
+
         '''
         This function will just create fake parts of the model
         Because LithTech needs at least something in every section!
         '''
         animation = Animation()
         animation.name = 'ConvertedFromPS2'
-        animation.extents = Vector((10, 10, 10))
+        animation.extents = Vector((0, 0, 0))
         animation.keyframes.append(Animation.Keyframe())
         for node_index, (node) in enumerate(model.nodes):
             transforms = list()
             for _ in animation.keyframes:
                 transform = Animation.Keyframe.Transform()
+                transform.matrix = node.bind_matrix
                 transforms.append(transform)
             animation.node_keyframe_transforms.append(transforms)
         model.animations.append(animation)
@@ -105,13 +112,15 @@ class ModelStubber(object):
         child_model = ChildModel()
 
         for _ in model.nodes:
+            # This number seems to have no basis on reality, so therefore it's now a teapot.
+            child_model.build_number = 418
             child_model.transforms.append(Animation.Keyframe.Transform())
         model.child_models.append(child_model)
 
         ''' AnimBindings '''
         anim_binding = AnimBinding()
-        anim_binding.name = 'base'
-        animation.extents = Vector((10, 10, 10))
+        anim_binding.name = 'ConvertedFromPS2'
+        anim_binding.origin = Vector((0, 0, 0))
         model.anim_bindings.append(anim_binding)
 
         # Save me some time renaming stuff..

--- a/src/importer.py
+++ b/src/importer.py
@@ -629,11 +629,11 @@ class ImportOperatorLTB(bpy.types.Operator, bpy_extras.io_utils.ImportHelper):
 
     def execute(self, context):
         # Load the model
-        try:
-            model = PS2LTBModelReader().from_file(self.filepath)
-        except Exception as e:
-            show_message_box(str(e), "Read Error", 'ERROR')
-            return {'CANCELLED'}
+        #try:
+        model = PS2LTBModelReader().from_file(self.filepath)
+        #except Exception as e:
+        #    show_message_box(str(e), "Read Error", 'ERROR')
+        #    return {'CANCELLED'}
         
         model.name = os.path.splitext(os.path.basename(self.filepath))[0]
         image = None

--- a/src/importer.py
+++ b/src/importer.py
@@ -267,6 +267,7 @@ def import_model(model, options):
             uv_texture = mesh.uv_layers[piece.material_index]
 
             # Set the correct UV as active
+            uv_texture.active = True
             uv_texture.active_render = True
 
             for face_index, face in enumerate(lod.faces):

--- a/src/importer.py
+++ b/src/importer.py
@@ -7,6 +7,7 @@ from math import pi
 from mathutils import Vector, Matrix, Quaternion, Euler
 from bpy.props import StringProperty, BoolProperty, FloatProperty
 from .dtx import DTX
+from .utils import show_message_box
 
 # Format imports
 from .reader_abc_pc import ABCModelReader
@@ -69,7 +70,7 @@ def import_model(model, options):
 
         if bone.parent is not None:
             bone.use_connect = bone.parent.tail == bone.head
-            print(bone.use_connect, node.is_removable)
+            #print(bone.use_connect, node.is_removable)
 
         '''
         Get the forward, left, and up vectors of the bone (used later for determining the roll).
@@ -628,7 +629,12 @@ class ImportOperatorLTB(bpy.types.Operator, bpy_extras.io_utils.ImportHelper):
 
     def execute(self, context):
         # Load the model
-        model = PS2LTBModelReader().from_file(self.filepath)
+        try:
+            model = PS2LTBModelReader().from_file(self.filepath)
+        except Exception as e:
+            show_message_box(str(e), "Read Error", 'ERROR')
+            return {'CANCELLED'}
+        
         model.name = os.path.splitext(os.path.basename(self.filepath))[0]
         image = None
         if self.should_import_textures:
@@ -647,7 +653,12 @@ class ImportOperatorLTB(bpy.types.Operator, bpy_extras.io_utils.ImportHelper):
         options.should_merge_pieces = self.should_merge_pieces
         options.should_clear_scene = self.should_clear_scene
         options.image = image
-        import_model(model, options)
+        try:
+            import_model(model, options)
+        except Exception as e:
+            show_message_box(str(e), "Import Error", 'ERROR')
+            return {'CANCELLED'}
+
         return {'FINISHED'}
 
     @staticmethod

--- a/src/importer.py
+++ b/src/importer.py
@@ -81,6 +81,12 @@ def import_model(model, options):
             X+: Right
             Y+: Up
             Z+: Forward
+
+        Jake: Animation wise, action_hero.abc seems to use...
+        
+        Y+: Forward
+        X-: Up
+        Z+: Right
         '''
         (forward, right, up) = map(lambda x: -x.xyz, node.bind_matrix.col[0:3])
 

--- a/src/reader_ltb_ps2.py
+++ b/src/reader_ltb_ps2.py
@@ -427,15 +427,23 @@ class PS2LTBModelReader(object):
 
                 print ("Looking for hero eights...")
                 while True:
-                    hero_eights = [ unpack('f', f)[0], unpack('f', f)[0], unpack('f', f)[0] ]
-                    #print("Value: ", hero_eights)
-                    #print("Close to 0.8? " , math.isclose(hero_eights[0], 0.8, rel_tol=1e-04))
-                    if math.isclose(hero_eights[0], 0.8, rel_tol=1e-04) and math.isclose(hero_eights[1], 0.8, rel_tol=1e-04) and math.isclose(hero_eights[2], 0.8, rel_tol=1e-04):
-                        print("Found 0.8,0.8,0.8")
-                        break
+                    try:
+                        hero_eights = [ unpack('f', f)[0], unpack('f', f)[0], unpack('f', f)[0] ]
+                        #print("Value: ", hero_eights)
+                        #print("Close to 0.8? " , math.isclose(hero_eights[0], 0.8, rel_tol=1e-04))
+                        if math.isclose(hero_eights[0], 0.8, rel_tol=1e-04) and math.isclose(hero_eights[1], 0.8, rel_tol=1e-04) and math.isclose(hero_eights[2], 0.8, rel_tol=1e-04):
+                            print("Found 0.8,0.8,0.8")
+                            break
 
-                    # We only want to move up one!
-                    f.seek(-4*2, 1)
+                        # We only want to move up one!
+                        f.seek(-4*2, 1)
+                    except struct.error as err:
+                        exit_piece_early = True
+                        print("Could not find hero eights, reached end of file.")
+                        break
+                        
+                if exit_piece_early == True:
+                    break
 
                 # Revert back to our original position
                 f.seek(-(4*5), 1) 

--- a/src/reader_ltb_ps2.py
+++ b/src/reader_ltb_ps2.py
@@ -602,7 +602,8 @@ class PS2LTBModelReader(object):
                             normal_padding = unpack('f', f)[0]
 
                             uv_data = Vector()
-                            uv_data.xy = unpack('2f', f)[0]
+                            uv_data.x = unpack('f', f)[0]
+                            uv_data.y = unpack('f', f)[0]
 
                             vertex_index = unpack('f', f)[0]
                             unknown_padding = unpack('f', f)[0]

--- a/src/reader_ltb_ps2.py
+++ b/src/reader_ltb_ps2.py
@@ -225,6 +225,9 @@ class PS2LTBModelReader(object):
         self._node_count = 0
         self._lod_count = 0
 
+        # Hack to count sockets
+        self._socket_counter = 0
+
     # Leftovers from ABC Model Reader
     def _read_matrix(self, f):
         data = unpack('16f', f)
@@ -333,6 +336,7 @@ class PS2LTBModelReader(object):
                 [self._read_transform(f) for _ in range(animation.keyframe_count)])
         return animation
 
+    
     def _read_socket(self, f):
         socket = Socket()
         # We don't know all the values here, so skip the ones we can't use yet.
@@ -343,6 +347,11 @@ class PS2LTBModelReader(object):
         f.seek(4, 1)
         socket.node_index = unpack('I', f)[0]
         f.seek(4 * 2, 1)
+
+        # Fill in some missing data
+        socket.name = "Socket" + str(self._socket_counter)
+        self._socket_counter += 1
+
         return socket
 
     def _read_anim_binding(self, f):

--- a/src/reader_ltb_ps2.py
+++ b/src/reader_ltb_ps2.py
@@ -156,9 +156,9 @@ class VertexList(object):
                 #print("Flipped? ",flip)
 
                 if flip:
-                    face.vertices = [ grouped_faces[i - 1].face_vertex, grouped_faces[i - 2].face_vertex, grouped_faces[i].face_vertex ]
+                    face.vertices = [ grouped_faces[i].face_vertex, grouped_faces[i - 1].face_vertex, grouped_faces[i - 2].face_vertex ]
                 else:
-                    face.vertices = [ grouped_faces[i - 2].face_vertex, grouped_faces[i - 1].face_vertex, grouped_faces[i].face_vertex ]
+                    face.vertices = [ grouped_faces[i].face_vertex, grouped_faces[i - 2].face_vertex, grouped_faces[i - 1].face_vertex ]
 
                 faces.append(face)
                 flip = not flip
@@ -608,6 +608,7 @@ class PS2LTBModelReader(object):
                             mesh_index += 1
                         # End For `i in range(data_count)`
 
+                        mesh_set_index += 1
                         running_mesh_data_count += data_count
                     # End While `running_mesh_data_count < mesh_data_count`
 

--- a/src/reader_ltb_ps2.py
+++ b/src/reader_ltb_ps2.py
@@ -292,11 +292,19 @@ class PS2LTBModelReader(object):
     def _read_node(self, f):
         node = Node()
         node.name = self._read_string(f)
-        node.index = unpack('H', f)[0]
-        node.flags = unpack('b', f)[0]
+        #node.index = unpack('H', f)[0]
+        #node.flags = unpack('H', f)[0]
         node.bind_matrix = self._read_matrix(f)
-        node.inverse_bind_matrix = node.bind_matrix.inverted()
+        #node.inverse_bind_matrix = node.bind_matrix.inverted()
+        f.seek(4, 1) 
         node.child_count = unpack('I', f)[0]
+        node.index = unpack('I', f)[0]
+
+        # I guess this is 0?
+        if node.index == 65536:
+            node.index = 0
+
+        #f.seek(4, 1)
         return node
 
     def _read_transform(self, f):
@@ -704,6 +712,12 @@ class PS2LTBModelReader(object):
 
             print("Final verticies ", len(lod.vertices))
             print("Final faces ", len(lod.faces))
+
+            # Handle Nodes!
+            f.seek(node_offset)
+
+            model.nodes = [self._read_node(f) for _ in range(node_count)]
+            build_undirected_tree(model.nodes)
 
             # section_name = self._read_string(f)
             # next_section_offset = unpack('i', f)[0]

--- a/src/reader_ltb_ps2.py
+++ b/src/reader_ltb_ps2.py
@@ -647,7 +647,7 @@ class PS2LTBModelReader(object):
                             vertex.normal = normal_data
 
                             # Local set list
-                            vertex_list.append(vertex, mesh_set_index, face_vertex, flag)
+                            vertex_list.append(vertex, mesh_set_index, face_vertex, False)
 
                             mesh_index += 1
                         # End For `i in range(data_count)`
@@ -720,6 +720,41 @@ class PS2LTBModelReader(object):
 
             print("Final verticies ", len(lod.vertices))
             print("Final faces ", len(lod.faces))
+
+            # Hacky! Handle Vertex Weights
+
+            # Let's seek to node offset
+            f.seek(node_offset)
+
+            # Then seek backwards based on the vertex count, and the size of the data
+            f.seek(-(vertex_count * (4*3)), 1)
+
+
+            for i in range(vertex_count):
+                weights = unpack('4H', f)
+                node_indexes = unpack('4B', f)
+                
+                normalized_weights = []
+
+                # Normlize our weights from 0..4096 to 0..1
+                for weight in weights:
+                    if weight == 0:
+                        continue
+
+                    normalized_weights.append(weight / 4096)
+
+                for j in range( len(normalized_weights) ):
+                    weight = Weight()
+                    # Set the normalized weight bias
+                    weight.weight_bias = normalized_weights[j]
+                    weight.node_index = node_indexes[j]
+                    # Dangerous, this is assuming the nodes are in proper order.
+                    # I doubt that's universally true, but so far I haven't seen anything that goes against that...
+                    if weight.node_index != 0:
+                        weight.node_index /= 4
+                        weight.node_index = int(weight.node_index)
+                    model.pieces[0].lods[0].vertices[i].weights.append(weight)
+
 
 
             # Handle Nodes!

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,6 +1,14 @@
 import bpy
 import bmesh
 
+# Displays a message box that's immensely more helpful than errors
+def show_message_box(message = "", title = "Message Box", icon = 'INFO'):
+
+    def draw(self, context):
+        self.layout.label(text=message)
+
+    bpy.context.window_manager.popup_menu(draw, title = title, icon = icon)
+
 
 def delete_all_objects():
     if bpy.ops.object.mode_set.poll():


### PR DESCRIPTION
Work in progress, do not merge!
---------------------------------

This script (will eventually) finishes off the NOLF 1 PS2 LTB mesh import. 

Most of my findings are located in /research/ps2_ltb.bt which is a binary template for 010 Editor.  (A C-like scripting language to help break data down.)

The format seems to be really optimized for the PS2. (Which makes sense..) It's packed together in a way that it's probably immediately ready to be shipped to the PS2's GS chip. Not too hard to decode though, but there's still some unknowns.

There seems to mainly be 1 lod per piece, and each lod has VIF commands surrounding it. The vertices are per-ordered with no index buffers for face information. I'm not sure how to piece together UV information, and my normals seem to be generating incorrectly, but in general the faces that are generated seem to be mostly okay. 

The mesh data seems to be chunked up by 13kb. (The max you can ship to the GS chip at a time is 16kb.) 

There's also a bunch of hacks thrown in to skip bone/weight information. 