### PR TITLE
Features/14 read ps2 ltb animations

### DIFF
--- a/research/ps2_ltb.bt
+++ b/research/ps2_ltb.bt
@@ -289,11 +289,23 @@ struct KeyFrame {
     char String[StringCount];
 };
 
+struct ThreeByte {
+    short x;
+    char xPlus;
+    short y;
+    char yPlus;
+    short z;
+    char zPlus;
+};
+
 
 
 struct CompressedFrame {
-    short Padding;
+    // Scale by 0x1000 if flag is 0
+    // Scale by 0x10 if flag is 1
     short Location[3]; 
+    short LocationScaleFlag;
+    // Scale by 0x4000
     short Rotation[4]; 
 };
 

--- a/research/ps2_ltb.bt
+++ b/research/ps2_ltb.bt
@@ -284,8 +284,9 @@ struct AnimationHeader {
 };
 
 struct KeyFrame {
-    ushort Time;
-    uint32 Padding;
+    uint32 Time;
+    short StringCount;
+    char String[StringCount];
 };
 
 
@@ -321,14 +322,16 @@ struct Animation (uint32 nodeCount) {
     uint32 Unk;
     uint32 InterpolationTime;
     uint32 KeyFrameCount;
-    KeyFrame KeyFrames[KeyFrameCount];
+    KeyFrame KeyFrames[KeyFrameCount] <optimize=false>;
+    //uint32 Unk2;
     
     // Maybe they're just compressed?
-    CVector3 Locations[KeyFrameCount];
-    CQuat Rotations[KeyFrameCount];
+    //CVector3 Locations[KeyFrameCount];
+    //CQuat Rotations[KeyFrameCount];
+
 
     //short test;
-    //NodeKeyframe Nodes(KeyFrameCount)[nodeCount];
+    NodeKeyframe Nodes(KeyFrameCount)[nodeCount] <optimize=false>;
 };//5052
 
 struct WeightHeader {
@@ -421,7 +424,8 @@ local int pad = 0;
 // Commented out so I can work on non-geom stuff
 
 // Okay, let's loop through the pieces
-for(i = 0; i < pieceInfo.PieceCount; i++)
+//for(i = 0; i < pieceInfo.PieceCount; i++)
+if (false)
 {
     Printf("----------\nNew Piece\n");
 
@@ -630,7 +634,9 @@ ChildModel ChildModels[info.ChildModelCount - 1] <optimize=false>;
 FSeek(hdr.AnimationOffset);
 AnimationHeader animationHdr;
 
-//Animation animation(info.NodeCount)[info.AnimationCount] <optimize=false>;
+// 162 bytes per animation for poodle
+
+Animation animation(info.NodeCount)[info.AnimationCount] <optimize=false>;
 
 
 

--- a/research/ps2_ltb.bt
+++ b/research/ps2_ltb.bt
@@ -150,7 +150,7 @@ struct LODSkeletal {
 // End LOD Zone!
 
 struct ModelInfoExtended {
-    uint32 WeightCount; // ??
+    uint32 HashValue; // Use rezCalcHash (from ps2rezdecoder) function with this value.
     uint32 unk1;
     uint32 unk2;
 };
@@ -265,7 +265,7 @@ struct Socket {
     Vector3 location;
     uint32 padding;
     uint32 nodeIndex;
-    uint32 unk2;
+    uint32 hashedString;
     uint32 unk3;
 };
 
@@ -331,7 +331,7 @@ struct NodeKeyframe (uint32 Count)
 struct Animation (uint32 nodeCount) {
     Vector3 Dims;
     Vector3 Translation;
-    uint32 Unk;
+    uint32 HashedString;
     uint32 InterpolationTime;
     uint32 KeyFrameCount;
     KeyFrame KeyFrames[KeyFrameCount] <optimize=false>;

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -14,6 +14,7 @@ bl_info = {
 
 if 'bpy' in locals():
     import importlib
+    if 'hash_ps2'           in locals(): importlib.reload(hash_ps2)
     if 's3tc'               in locals(): importlib.reload(s3tc)
     if 'dxt'                in locals(): importlib.reload(dtx)
     if 'abc'                in locals(): importlib.reload(abc)
@@ -27,6 +28,7 @@ if 'bpy' in locals():
     if 'converter'          in locals(): importlib.reload(converter)
 
 import bpy
+from . import hash_ps2
 from . import s3tc
 from . import dtx
 from . import abc
@@ -38,6 +40,7 @@ from . import writer_lta_pc
 from . import importer
 from . import exporter
 from . import converter
+
 
 from bpy.utils import register_class, unregister_class
 

--- a/src/hash_ps2.py
+++ b/src/hash_ps2.py
@@ -1,13 +1,11 @@
 from ctypes import c_int
 
 # Lookup table for our hashin'
+# These values must be datamined,
+# I've included known values for the new PS2 stuff in NOLF 1.
 HASH_LOOKUP = {
     "sockets" : [
-        #############
-        # Sockets
-        #############
         # Characters
-        "RightHand",
         "Head",
         "Eyes",
         "Back",
@@ -15,16 +13,13 @@ HASH_LOOKUP = {
         "Chin",
         "LeftHand",
         "LeftFoot",
-        
+        "RightHand",
         "RightFoot",
         "Snowmobile",
         "Motorcycle",
     ],
 
     "animations" : [
-        #############
-        # Animations
-        #############
         # Characters
         "base",
         "StandHip",

--- a/src/hash_ps2.py
+++ b/src/hash_ps2.py
@@ -1,0 +1,81 @@
+from ctypes import c_int
+
+# Lookup table for our hashin'
+HASH_LOOKUP = {
+    "sockets" : [
+        #############
+        # Sockets
+        #############
+        # Characters
+        "RightHand",
+        "Head",
+        "Eyes",
+        "Back",
+        "Nose",
+        "Chin",
+        "LeftHand",
+        "LeftFoot",
+        
+        "RightFoot",
+        "Snowmobile",
+        "Motorcycle",
+    ],
+
+    "animations" : [
+        #############
+        # Animations
+        #############
+        # Characters
+        "base",
+        "StandHip",
+        # Weapons
+        "SelectMelee",
+        "AltIdle_0",
+        "AltFire",
+        "AltFire1",
+        "AltIdle_1",
+        "AltIdle_2",
+        "AltDeselect",
+        "Select1",
+        "Idle_0",
+        "Idle_1",
+        "Idle_2",
+        "Deselect",
+        "Fire",
+        "AltSelect",
+        "Select"
+    ]
+}
+
+'''
+HashLookUp
+Original hash code reverse engineered from NOLF PS2 rez module
+Ported to Python, it relies on overflowing signed integers, hence the ctypes!
+'''
+class HashLookUp(object):
+    def __init__(self, magic_number):
+        self._magic_number = magic_number
+        pass
+
+    def lookup_hash(self, hash_value, category):
+        for string in HASH_LOOKUP[category]:
+
+            hashed = self.hash(string)
+            if hashed == c_int(hash_value).value:
+                return string
+
+        return None
+
+    def hash(self, name):
+        hash_value = c_int(0)
+        for char in name:
+            char = char.upper()
+            byte_char = ord(char)
+            byte_char = byte_char & 0xFF
+            if (byte_char == 0x2F):
+                byte_char = 0x5C
+            hash_value.value = hash_value.value + c_int(byte_char).value + hash_value.value * c_int(self._magic_number).value
+        return hash_value.value
+
+# End Class
+

--- a/src/importer.py
+++ b/src/importer.py
@@ -607,9 +607,9 @@ class ImportOperatorLTB(bpy.types.Operator, bpy_extras.io_utils.ImportHelper):
         # box.row().prop(self, 'should_import_textures')
         # # box.row().prop(self, 'should_assign_materials')
 
-        # box = layout.box()
-        # box.label(text='Animations')
-        # box.row().prop(self, 'should_import_animations')
+        box = layout.box()
+        box.label(text='Animations')
+        box.row().prop(self, 'should_import_animations')
 
         box = layout.box()
         box.label(text='Misc')
@@ -637,6 +637,7 @@ class ImportOperatorLTB(bpy.types.Operator, bpy_extras.io_utils.ImportHelper):
         options.bone_length_min = self.bone_length_min
         options.should_import_lods = self.should_import_lods
         options.should_import_animations = self.should_import_animations
+        options.should_import_vertex_animations = False
         options.should_import_sockets = self.should_import_sockets
         options.should_merge_pieces = self.should_merge_pieces
         options.should_clear_scene = self.should_clear_scene

--- a/src/reader_ltb_ps2.py
+++ b/src/reader_ltb_ps2.py
@@ -310,24 +310,26 @@ class PS2LTBModelReader(object):
 
         transform = Animation.Keyframe.Transform()
 
-        # Always 0xFFFFFFFF?
-        
-        padding = unpack('H', f)[0]
+        # Unpack and transform the values
+        location = unpack('3h', f)
+        location_small_scale = unpack('h', f)[0] # Flag
+        rotation = unpack('4h', f)
 
-        location = unpack('3H', f)
-        rotation = unpack('4H', f)
+        # Constants..kinda. If location small scale is 0, then SCALE_LOC can change.
+        SCALE_ROT = 0x4000
+        SCALE_LOC = 0x10
 
-        # Transform the values
-        MAX = 16384
+        if location_small_scale == 0:
+            SCALE_LOC = 0x1000
 
-        transform.location.x = location[0] / MAX
-        transform.location.y = location[1] / MAX
-        transform.location.z = location[2] / MAX
+        transform.location.x = location[0] / SCALE_LOC
+        transform.location.y = location[1] / SCALE_LOC
+        transform.location.z = location[2] / SCALE_LOC
 
-        transform.rotation.x = rotation[0] / MAX
-        transform.rotation.y = rotation[1] / MAX
-        transform.rotation.z = rotation[2] / MAX
-        transform.rotation.w = rotation[3] / MAX
+        transform.rotation.x = rotation[0] / SCALE_ROT
+        transform.rotation.y = rotation[1] / SCALE_ROT
+        transform.rotation.z = rotation[2] / SCALE_ROT
+        transform.rotation.w = rotation[3] / SCALE_ROT
 
         return transform
 


### PR DESCRIPTION
Resolves #14 

PS2 animations now work, hurray!
![image](https://user-images.githubusercontent.com/3683240/89137092-9aef5280-d4eb-11ea-81e8-5b1bb2ac9424.png)

Monolith compressed some animation keyframes, so we shouldn't use them if they're available on the PC version. But exclusive animations can now be brought over. 